### PR TITLE
fix: support version ranges

### DIFF
--- a/convert_poetry2uv.py
+++ b/convert_poetry2uv.py
@@ -24,12 +24,18 @@ def argparser() -> argparse.Namespace:
 def version_conversion(version: str) -> str:
     gt_tilde_version = re.compile(r"[\^~](\d.*)")
     tilde_with_digits_and_star = re.compile(r"^~([\d\.]+)\.\*")
+    version_constraints = re.compile(r'^((?:[<>]=?|==)\s*[\d.]+(?:\s+(?:[<>]=?|==)\s*[\d.]+)*)')
+    
     if version == "*":
         return ""
     elif found := tilde_with_digits_and_star.match(version):
         return f">={found[1]}"
     elif found := gt_tilde_version.match(version):
         return f">={found[1]}"
+    elif found := version_constraints.match(version):
+        # Convert space-separated version constraints to comma-separated
+        return version.replace(' < ', ',<').replace(' <= ', ',<=').replace(' > ', ',>').replace(
+            ' >= ', ',>=').replace(' == ', ',==').replace(' ', '')
     else:
         print(f"Well, this is an unexpected version\nVersion = {version}\n")
         raise ValueError


### PR DESCRIPTION
Thank you @bartdorlandt for creating this script! 

Currently the [openapi-generator-cli](https://github.com/OpenAPITools/openapi-generator-cli) outputs a `pyproject.toml` in Poetry format so I've been using this project to convert the auto-generated `pyproject.toml` to one that UV can use to build OpenAPI clients from. 

When using the generator I found that version ranges are not supported in this project. This PR should add support for converting version ranges in Poetry's format to PEP-508's standard.