### PR TITLE
Poetry v2 support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.12
+current_version = 0.1.13
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.12
+current_version = 0.2.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.0
 commit = True
 tag = False
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.13
+current_version = 0.1.12
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.2.0
 commit = True
-tag = True
+tag = False
 tag_name = {new_version}
 
 [bumpversion:file:pyproject.toml]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The convert_poetry2uv.py script is meant to easily convert the pyproject.toml to be consumed by `uv` instead of `poetry`.
 
-> It is specifically meant for the poetry syntax prior to version 2.0. The 2.0 release is compliant to the [PEP 621](https://peps.python.org/pep-0621/) specification. The script will not work for the 2.0 release!
+> Poetry v2 came out after this tool. The tool has been modified to work with poetry v2 format as well. Please create an issue/PR if you find any issues.
 
 It has a dry-run flag, to have a temporary file to validate the output. When not running the dry-run the original file is saved with a .org extension.
 
@@ -12,7 +12,7 @@ You may need to make some manual changes.
 The layout might not be exactly to your liking. I would recommend using [Even better toml](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) in VSCode. Just open the newly generated toml file and save. It will format the file according to the toml specification.
 
 ## Caveats
-* If you were using the poetry build-system, it will be replaced by hatchling.
+* If you were using the poetry build-system, it is removed in the generated pyproject.toml.
 * if you had optional dev groups, the dev group libraries will be used, the optional flag is removed
 
 # Using as a tool

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,11 +32,15 @@ tasks:
   bump:patch:
     desc: "Update the patch version and tag"
     cmds:
-      - uv sync
       - uv run bumpversion patch
+      - uv sync
+      - git commit -a uv.lock -m "Updated uv.lock"
+      - git tag -a $(bump2version --verbose | grep "current_version ="" | cut -d' = ' -f2)
 
   bump:minor:
     desc: "Update the minor version and tag"
     cmds:
-      - uv sync
       - uv run bumpversion minor
+      - uv sync
+      - git commit -a uv.lock -m "Updated uv.lock"
+      - git tag -a $(bump2version --verbose | grep "current_version ="" | cut -d' = ' -f2)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,13 +34,13 @@ tasks:
     cmds:
       - uv run bumpversion patch
       - uv sync
-      - git commit -a uv.lock -m "Updated uv.lock"
-      - git tag -a $(bump2version --verbose | grep "current_version ="" | cut -d' = ' -f2)
+      - git commit uv.lock -m "Updated uv.lock"
+      - git tag -a $(cat .bumpversion.cfg | grep "current_version = " | awk '{print $3}') -m ""
 
   bump:minor:
     desc: "Update the minor version and tag"
     cmds:
       - uv run bumpversion minor
       - uv sync
-      - git commit -a uv.lock -m "Updated uv.lock"
-      - git tag -a $(bump2version --verbose | grep "current_version ="" | cut -d' = ' -f2)
+      - git commit uv.lock -m "Updated uv.lock"
+      - git tag -a $(cat .bumpversion.cfg | grep "current_version = " | awk '{print $3}') -m ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "convert-poetry2uv"
-version = "0.2.1"
+version = "0.2.0"
 description = "Poetry to uv tool. To migrate from a poetry managed repo to uv."
 authors = [{ "name" = "Bart", "email" = "bart@bamweb.nl" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "convert-poetry2uv"
-version = "0.2.0"
+version = "0.2.1"
 description = "Poetry to uv tool. To migrate from a poetry managed repo to uv."
 authors = [{ "name" = "Bart", "email" = "bart@bamweb.nl" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "convert-poetry2uv"
-version = "0.1.12"
+version = "0.1.13"
 description = "Poetry to uv tool. To migrate from a poetry managed repo to uv."
 authors = [{ "name" = "Bart", "email" = "bart@bamweb.nl" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "convert-poetry2uv"
-version = "0.1.13"
+version = "0.1.12"
 description = "Poetry to uv tool. To migrate from a poetry managed repo to uv."
 authors = [{ "name" = "Bart", "email" = "bart@bamweb.nl" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "convert-poetry2uv"
-version = "0.1.12"
+version = "0.2.0"
 description = "Poetry to uv tool. To migrate from a poetry managed repo to uv."
 authors = [{ "name" = "Bart", "email" = "bart@bamweb.nl" }]
 readme = "README.md"

--- a/tests/files/uv_pyproject.toml
+++ b/tests/files/uv_pyproject.toml
@@ -40,9 +40,6 @@ script_name = "dir.file:app"
 [dependency-groups]
 dev = ["mypy"]
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
 
 [tool.mypy]
 python_version = "3.12"

--- a/tests/files/v2_poetry_converted.toml
+++ b/tests/files/v2_poetry_converted.toml
@@ -1,0 +1,12 @@
+[project]
+name = "p2"
+version = "0.1.0"
+description = "poetry 2.1.1 test dir"
+authors = [{ name = "Bart Dorlandt", email = "bart@bamweb.nl" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = ["jira (>=3.8.0,<4.0.0)"]
+
+[dependency-groups]
+dev = ["ruff>=0.11.2", "pytest>=8.3.5", "mypy>=1.15.0", "pytest-cov>=6.0.0", "pytest-mock>=3.14.0"]

--- a/tests/files/v2_poetry_pyproject.toml
+++ b/tests/files/v2_poetry_pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "p2"
+version = "0.1.0"
+description = "poetry 2.1.1 test dir"
+authors = [{ name = "Bart Dorlandt", email = "bart@bamweb.nl" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = ["jira (>=3.8.0,<4.0.0)"]
+
+[tool.poetry]
+
+[tool.poetry.group.dev.dependencies]
+ruff = "^0.11.2"
+pytest = "^8.3.5"
+mypy = "^1.15.0"
+pytest-cov = "^6.0.0"
+pytest-mock = "^3.14.0"
+
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "convert-poetry2uv"
-version = "0.2.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "tomlkit" },

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "convert-poetry2uv"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "tomlkit" },

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "convert-poetry2uv"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "tomlkit" },

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "convert-poetry2uv"
-version = "0.1.12"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "tomlkit" },


### PR DESCRIPTION
With the release it should work with pyproject.toml files that were converted or generated by poetry version 2. 

This release doesn't convert the poetry-core build system to hatchling. It will not create a build-system.